### PR TITLE
Apk Zipalign Verification failure fix

### DIFF
--- a/src/io-utils.ts
+++ b/src/io-utils.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 export function findReleaseFiles(releaseDir: string): Dirent[] | undefined {
     const releaseFiles = fs.readdirSync(releaseDir, {withFileTypes: true})
         .filter(item => !item.isDirectory())
-        .filter(item => item.name.endsWith(".apk") || item.name.endsWith(".aab"));
+        .filter(item => item.name.endsWith("Signed.apk") || item.name.endsWith(".aab"));
 
     console.log("Found " + releaseFiles.length + " release files.")
 


### PR DESCRIPTION
Sign file which ends with 'Signed.apk' otherwise zipalign verification will fail